### PR TITLE
support ViewsPath set in conf/app.conf

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,14 @@ func Render(beegoCtx *context.Context, tmpl string, ctx Context) {
 
 	if !ok || devMode {
 		var err error
-		template, err = p2.FromFile("templates/" + tmpl)
+
+		// default ViewsPath
+		prefix := beego.AppConfig.String("ViewsPath")
+		if prefix == "" {
+			prefix = "views/"
+		}
+
+		template, err = p2.FromFile(prefix + tmpl)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Developer could get template from the folder set in conf/app.conf.
The default path is `views/` which is the default path in beego.